### PR TITLE
Change counter into bigint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ yield the following:
     requestId: {
       originatorId: '90-b3-d5-1f-30-01-00-00',
       targetId: '00-db-12-34-56-78-90-a0',
-      counter: 1000
+      counter: 1000n
     },
     commandVariant: {
       number: 1,
@@ -79,6 +79,7 @@ To aid with interrogating a DUIS response to determine what type of response is
 provided a number of utility functions are provided:
 
   * `isSimplifiedDuisInput`
+  * `isSimplifiedDuisInputRequest`
   * `isSimplifiedDuisOutput`
   * `isSimplifiedDuisOutputRequest`
   * `isSimplifiedDuisOutputResponse`
@@ -122,7 +123,7 @@ above.
     requestId: {
       originatorId: '90-b3-d5-1f-30-01-00-00',
       targetId: '00-db-12-34-56-78-90-a0',
-      counter: 1000
+      counter: 1000n
     },
     commandVariant: '1',
     serviceReference: '4.1',

--- a/src/duis.ts
+++ b/src/duis.ts
@@ -23,7 +23,7 @@ import { isServiceReferenceVariant, ServiceReferenceVariant } from './srv'
 export interface RequestId {
   originatorId: string
   targetId: string
-  counter: number
+  counter: bigint
 }
 
 export function isRequestId(o: unknown): o is RequestId {
@@ -34,7 +34,7 @@ export function isRequestId(o: unknown): o is RequestId {
     'originatorId' in x &&
     'targetId' in x &&
     'counter' in x &&
-    typeof x.counter === 'number' &&
+    typeof x.counter === 'bigint' &&
     typeof x.targetId === 'string' &&
     typeof x.originatorId === 'string'
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ function parseRequestID(id: string): RequestId {
       return {
         originatorId: parts[0],
         targetId: parts[1],
-        counter: Number(parts[2]),
+        counter: BigInt(parts[2]),
       }
     }
   }

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -31,7 +31,7 @@ describe('constructDuis/simple', () => {
           requestId: {
             originatorId: '90-B3-D5-1F-30-01-00-00',
             targetId: '00-DB-12-34-56-78-90-A3',
-            counter: 9001,
+            counter: BigInt(9001),
           },
           serviceReference: '4.1',
           serviceReferenceVariant: srv.lookupSRV(
@@ -56,7 +56,7 @@ describe('constructDuis/simple', () => {
           requestId: {
             originatorId: '90-B3-D5-1F-30-01-00-00',
             targetId: '00-DB-12-34-56-78-90-A3',
-            counter: 9001,
+            counter: BigInt(9001),
           },
           serviceReference: '4.1',
           serviceReferenceVariant: '4.1.1',
@@ -78,7 +78,7 @@ describe('constructDuis/simple', () => {
           requestId: {
             originatorId: '90-B3-D5-1F-30-01-00-00'.toLowerCase(),
             targetId: '00-DB-12-34-56-78-90-A3'.toLowerCase(),
-            counter: 9001,
+            counter: BigInt(9001),
           },
           serviceReference: '4.1',
           serviceReferenceVariant: srv.lookupSRV(
@@ -102,7 +102,7 @@ describe('constructDuis/simple', () => {
           requestId: {
             originatorId: '90-B3-D5-1F-30-01-00-00',
             targetId: '00-DB-12-34-56-78-90-A3',
-            counter: 9001,
+            counter: BigInt(9001),
           },
           serviceReference: '4.1',
           serviceReferenceVariant: '4.1.1',
@@ -126,7 +126,7 @@ describe('constructDuis/simple', () => {
           requestId: {
             originatorId: '90-B3-D5-1F-30-01-00-00',
             targetId: '00-DB-12-34-56-78-90-A3',
-            counter: 9001,
+            counter: BigInt(9001),
           },
           responseCode: 'E65',
           responseDateTime: '2022-07-22T09:37:56.134Z',
@@ -151,7 +151,7 @@ describe('constructDuis/simple', () => {
           requestId: {
             originatorId: '90-b3-d5-1f-30-01-00-00',
             targetId: '00-db-12-34-56-78-90-a3',
-            counter: 9001,
+            counter: BigInt(9001),
           },
           responseCode: 'E65',
           responseDateTime: '2022-07-22T09:37:56.134Z',
@@ -175,7 +175,7 @@ describe('constructDuis/simple', () => {
           responseId: {
             originatorId: '90-b3-d5-1f-30-01-00-00',
             targetId: '00-db-12-34-56-78-90-a3',
-            counter: 9001,
+            counter: BigInt(9001),
           },
           responseCode: 'E65',
           responseDateTime: '2022-07-22T09:37:56.134Z',

--- a/test/is.test.ts
+++ b/test/is.test.ts
@@ -304,7 +304,7 @@ describe('typeing judgements', () => {
         duis.isRequestId({
           originatorId: 'string',
           targetId: 'string',
-          counter: 0,
+          counter: BigInt(0),
         })
       ).toBeTruthy()
     })
@@ -313,7 +313,7 @@ describe('typeing judgements', () => {
       expect(
         duis.isRequestId({
           targetId: 'string',
-          counter: 0,
+          counter: BigInt(0),
         })
       ).toBeFalsy()
     })
@@ -321,7 +321,7 @@ describe('typeing judgements', () => {
       expect(
         duis.isRequestId({
           originatorId: 'string',
-          counter: 0,
+          counter: BigInt(0),
         })
       ).toBeFalsy()
     })
@@ -410,7 +410,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -430,7 +430,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -449,7 +449,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -483,7 +483,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -503,7 +503,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
           },
@@ -522,7 +522,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
           },
@@ -560,12 +560,12 @@ describe('typeing judgements', () => {
           requestId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseCode: 'string',
           responseDateTime: 'string',
@@ -580,7 +580,7 @@ describe('typeing judgements', () => {
           responseId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseCode: 'string',
           responseDateTime: 'string',
@@ -595,7 +595,7 @@ describe('typeing judgements', () => {
           requestId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseCode: 'string',
           responseDateTime: 'string',
@@ -610,12 +610,12 @@ describe('typeing judgements', () => {
           requestId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseCode: 'string',
           responseDateTime: 'string',
@@ -635,7 +635,7 @@ describe('typeing judgements', () => {
           responseId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseCode: 'string',
           responseDateTime: 'string',
@@ -650,7 +650,7 @@ describe('typeing judgements', () => {
           requestId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseId: null,
           responseCode: 'string',
@@ -666,12 +666,12 @@ describe('typeing judgements', () => {
           requestId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseDateTime: 'string',
         })
@@ -685,12 +685,12 @@ describe('typeing judgements', () => {
           requestId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseId: {
             originatorId: 'string',
             targetId: 'string',
-            counter: 0,
+            counter: BigInt(0),
           },
           responseCode: 'string',
         })
@@ -861,7 +861,7 @@ describe('typeing judgements', () => {
               requestId: {
                 originatorId: 'string',
                 targetId: 'string',
-                counter: 0,
+                counter: BigInt(0),
               },
               serviceReference: 'string',
               serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -934,12 +934,12 @@ describe('typeing judgements', () => {
               requestId: {
                 originatorId: 'string',
                 targetId: 'string',
-                counter: 0,
+                counter: BigInt(0),
               },
               responseId: {
                 originatorId: 'string',
                 targetId: 'string',
-                counter: 0,
+                counter: BigInt(0),
               },
               responseCode: 'string',
               responseDateTime: 'string',
@@ -982,7 +982,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -1001,7 +1001,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: 'string',
@@ -1041,7 +1041,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -1059,7 +1059,7 @@ describe('typeing judgements', () => {
             responseId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             responseCode: 'string',
             responseDateTime: 'string',
@@ -1098,7 +1098,7 @@ describe('typeing judgements', () => {
             responseId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             responseCode: 'string',
             responseDateTime: 'string',
@@ -1122,7 +1122,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -1162,7 +1162,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: 'string',
@@ -1181,7 +1181,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: 'string',
@@ -1200,7 +1200,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -1219,7 +1219,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: 'string',
@@ -1250,7 +1250,7 @@ describe('typeing judgements', () => {
               requestId: {
                 originatorId: 'string',
                 targetId: 'string',
-                counter: 0,
+                counter: BigInt(0),
               },
               serviceReference: 'string',
               serviceReferenceVariant: 'string',
@@ -1291,7 +1291,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: 'string',
@@ -1310,7 +1310,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: 'string',
@@ -1329,7 +1329,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: srv.lookupSRV('1.1.1'),
@@ -1348,7 +1348,7 @@ describe('typeing judgements', () => {
             requestId: {
               originatorId: 'string',
               targetId: 'string',
-              counter: 0,
+              counter: BigInt(0),
             },
             serviceReference: 'string',
             serviceReferenceVariant: 'string',
@@ -1379,7 +1379,7 @@ describe('typeing judgements', () => {
               requestId: {
                 originatorId: 'string',
                 targetId: 'string',
-                counter: 0,
+                counter: BigInt(0),
               },
               serviceReference: 'string',
               serviceReferenceVariant: 'string',

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -109,7 +109,7 @@ describe('parser SRV 4.1.1/simplified', () => {
           requestId: {
             originatorId: '90-b3-d5-1f-30-01-00-00',
             targetId: '00-db-12-34-56-78-90-a3',
-            counter: 1000,
+            counter: BigInt(1000),
           },
           serviceReference: '4.1',
           serviceReferenceVariant: srv.lookupSRV(


### PR DESCRIPTION
`number` in JS is only supports 53 bit integers, thus converting into `bigint` to allow for 64 bit integers. 