### PR TITLE
fix: dependabot eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     assignees:
-      - "kazkansouh"
+      - kazkansouh
 
   - package-ecosystem: npm
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     assignees:
-      - "kazkansouh"
+      - kazkansouh
+    groups:
+      typescript-eslint:
+        patterns: ["@typescript-eslint/*"]


### PR DESCRIPTION
Group all @typescript-eslint/* packages into a single PR, this is to fix peerDependency issues that causes CI tests to fail.